### PR TITLE
Invul dash and god mode

### DIFF
--- a/src/classes/Actor.js
+++ b/src/classes/Actor.js
@@ -24,8 +24,14 @@ export class Actor extends Physics.Arcade.Sprite {
     getBody() {
         return this.body;
     }
-    setHP(damage) {
-        this.#hp -= damage;
+    setHP(damage, ignoreInvul = false) {
+        if (this.getGodMode?.()) return;
+
+        if (!this.getIsInvul?.() || ignoreInvul) {
+            this.#hp -= damage;
+        } else {
+            console.log("invul to dmg")
+        }
     }
 
 }       

--- a/src/classes/RoguePlayer.js
+++ b/src/classes/RoguePlayer.js
@@ -21,6 +21,8 @@ export class RoguePlayer extends Actor {
     #shootingSpeed = 0.8;
     #reloadTime = 1.5;
     #shootCooldown = false;
+    #isInvul = false;
+    #godMode = false;
 
 
     constructor(scene, x, y, playerModel) {
@@ -38,6 +40,18 @@ export class RoguePlayer extends Actor {
         scene.physics.add.overlap(this, scene.allEnemies, (_, enemy) => {
             this.handleMelee(_, enemy)
         })
+    }
+    getGodMode() {
+        return this.#godMode;
+    }
+    setGodMode(bool){
+        this.#godMode = bool;
+    }
+    getIsInvul() {
+        return this.#isInvul;
+    }
+    setIsInvul(bool) {
+        return this.#isInvul = bool;
     }
     getDashDistanceMultiplier() {
         return this.#dashDistanceMultiplier;
@@ -170,12 +184,14 @@ export class RoguePlayer extends Actor {
         const dashMultiplier = 200 + this.getDashDistanceMultiplier();
         this.anims.play("rogue_dash", true);
         this.setVelocityX(500 * this.scaleX);
+        !this.getGodMode() && this.setIsInvul(true);
         this.setDashCooldown(true);
         this.setIsDashing(true);
         this.scene.time.delayedCall(dashMultiplier, () => {
             this.setVelocityX(0)
             this.anims?.stop('rogue_dash');
             this.setIsDashing(false);
+            !this.getGodMode() && this.setIsInvul(false);
         })
         this.scene.time.delayedCall(dashMultiplier + this.getDashCooldownSpeed(), () => { this.setDashCooldown(false) } );
     }


### PR DESCRIPTION
Dash now applies invul to dash through attacks. Works well with projectiles Enemy melee is a bit iffy but I think thats the current melee handler.

- new ignoreInvul parameter on setHP() for attacks that cannot be dashed through.
- godMode can be enabled mainly for testing purposes to ignore all attack damage (and in future map damage such as fire/traps etc)